### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 test: unit-tests
 
 unit-tests: $(tests_binary)
-	$^ --sequential
+	$^ --sequential --shuffle
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
