### PR TITLE
Fix make lint to use corral run and fetch deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -48,7 +49,8 @@ $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) |
 	$(PONYC) -o $(BUILD_DIR) $(EXAMPLES_DIR)/$*
 
 lint:
-	pony-lint .
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
 
 clean:
 	$(CLEAN_DEPENDENCIES_WITH)


### PR DESCRIPTION
The lint target was calling pony-lint directly without fetching dependencies first and without going through corral, matching the pattern used across other ponylang projects.